### PR TITLE
OmniLightShadow.removeCaster() method fix

### DIFF
--- a/src/alternativa/engine3d/shadows/OmniLightShadow.as
+++ b/src/alternativa/engine3d/shadows/OmniLightShadow.as
@@ -901,7 +901,12 @@ package alternativa.engine3d.shadows {
 		public function removeCaster(object:Object3D):void {
 			var index:int = _casters.indexOf(object);
 			if (index < 0) throw new Error("Caster not found");
-			_casters[index] = _casters.pop();
+			if (index == _casters.length - 1) {
+				_casters.pop();
+			}
+			else {
+				_casters[index] = _casters.pop();
+			}
 		}
 
 		/**


### PR DESCRIPTION
The removeCaster() method was fixed: it seems like removing a caster from the end of the _casters vector won't work. For example, if _casters has only one element then calling 
_casters[0] = _casters.pop();
will first remove that element from vector (with pop() method) and then add it again with the same index.

Метод removeCaster() был исправлен: похоже, удаление с его помощью последнего объекта из вектора _casters не сработает. Например, если вектор _casters имеет всего один элемент, то выполнение
_casters[0] = _casters.pop();
сначала удалит тот элемент из вектора (_casters.pop()), а затем добавит его вновь с тем же индексом.
