### PR TITLE
Fix bugs with new asc2.0 compiler

### DIFF
--- a/src/alternativa/engine3d/animation/AnimationController.as
+++ b/src/alternativa/engine3d/animation/AnimationController.as
@@ -8,12 +8,12 @@
 
 package alternativa.engine3d.animation {
 
+	import flash.utils.Dictionary;
+	import flash.utils.getTimer;
+	
 	import alternativa.engine3d.alternativa3d;
 	import alternativa.engine3d.animation.events.NotifyEvent;
 	import alternativa.engine3d.core.Object3D;
-
-	import flash.utils.Dictionary;
-	import flash.utils.getTimer;
 
 	use namespace alternativa3d;
 	/**
@@ -170,7 +170,7 @@ package alternativa.engine3d.animation {
 				var j:int;
 				var count:int;
 				if (object is Object3D) {
-					index = _object3ds.indexOf(object);
+					index = _object3ds.indexOf(object as Object3D);
 					count = _object3ds.length - 1;
 					j = index + 1;
 					while (index < count) {

--- a/src/alternativa/engine3d/animation/keys/NumberTrack.as
+++ b/src/alternativa/engine3d/animation/keys/NumberTrack.as
@@ -26,7 +26,7 @@ package alternativa.engine3d.animation.keys {
 		 */
 		alternativa3d var keyList:NumberKey;
 
-		private var lastKey:NumberKey;
+		private var _lastKey:NumberKey;
 
 		/**
 		 * @private
@@ -47,7 +47,7 @@ package alternativa.engine3d.animation.keys {
 		 * @private
 		 */
 		override alternativa3d function get lastKey():Keyframe {
-			return lastKey;
+			return _lastKey;
 		}
 
 
@@ -55,7 +55,7 @@ package alternativa.engine3d.animation.keys {
 		 * @private
 		 */
 		override alternativa3d function set lastKey(value:Keyframe):void {
-			lastKey = NumberKey(value);
+			_lastKey = NumberKey(value);
 		}
 
 		/**

--- a/src/alternativa/engine3d/animation/keys/TransformTrack.as
+++ b/src/alternativa/engine3d/animation/keys/TransformTrack.as
@@ -24,7 +24,7 @@ package alternativa.engine3d.animation.keys {
 
 		private var keyList:TransformKey;
 
-		private var lastKey:TransformKey;
+		private var _lastKey:TransformKey;
 
 		/**
 		 * @private
@@ -45,14 +45,14 @@ package alternativa.engine3d.animation.keys {
 		 * @private
 		 */
 		override alternativa3d function get lastKey():Keyframe {
-			return lastKey;
+			return _lastKey;
 		}
 
 		/**
 		 * @private
 		 */
 		override alternativa3d function set lastKey(value:Keyframe):void {
-			lastKey = TransformKey(value);
+			_lastKey = TransformKey(value);
 		}
 
 		/**


### PR DESCRIPTION
Current repo has:
- same name getter-setters and property in some classes;
- indexOf with Object on vector with Object3D;

only with that fixes Alternativa3D can compile with asc2.0.
