### PR TITLE
Add to Ignore Bin Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Build and Release Folders
 bin-debug/
 bin-release/
+bin/
 target/
 out/
 


### PR DESCRIPTION
bin folder has created flash builder for actionscript library projects. So we don't needed it in repo
