### PR TITLE
convolution filter must be optional

### DIFF
--- a/src/alternativa/engine3d/resources/BitmapTextureResource.as
+++ b/src/alternativa/engine3d/resources/BitmapTextureResource.as
@@ -90,7 +90,7 @@ package alternativa.engine3d.resources {
 					if (rect.height == 0) rect.height = 1;
 					if (current != source) current.dispose();
 					current = new BitmapData(rect.width, rect.height, source.transparent, 0);
-					current.draw(bmp, matrix, null, null, null, false);
+					current.draw(bmp, matrix, null, null, null, !applyFilter);
 					Texture(_texture).uploadFromBitmapData(current, level++);
 				}
 				if (current != source) current.dispose();


### PR DESCRIPTION
I think this monocle screenshot explains why:

![](http://i47.tinypic.com/1gp0z9.png)
