### PR TITLE
Adding Geometry clone function.

### DIFF
--- a/src/alternativa/engine3d/resources/Geometry.as
+++ b/src/alternativa/engine3d/resources/Geometry.as
@@ -142,6 +142,34 @@ package alternativa.engine3d.resources {
 		}
 
 		/**
+		 * Returns a copy of object.
+		 * @return A copy of this <code>Geometry</code>.
+		 */
+		public function clone():Geometry
+		{
+			var geometry:Geometry = new Geometry();
+			geometry.clonePropertiesFrom(this);
+			return geometry;
+		}
+		
+		/**
+		 * Copies basic properties of <code>Geometry</code>. This method calls from  <code>clone()</code> method.
+		 * @param source <code>Geometry</code>, properties of  which will be copied.
+		 */
+		protected function clonePropertiesFrom(source:Geometry):void {
+			var n:int = source._vertexStreams.length;
+			for (var i:int = 0; i < n; ++i)
+			{
+				addVertexStream(source.getVertexStreamAttributes(i));
+				_vertexStreams[i].data.length = source._vertexStreams[i].data.length;
+				_vertexStreams[i].data.writeBytes(source._vertexStreams[i].data);
+				_vertexStreams[i].data.position = source._vertexStreams[i].data.position;
+			}
+			_numVertices = source._numVertices;
+			_indices = source._indices.slice();
+		}
+		
+		/**
 		 * Calculation of vertex normals.
 		 */
 		public function calculateNormals():void {


### PR DESCRIPTION
Maybe someone will find a use for this. I use it to allow editing of the geometry of a cloned mesh. Note that Mesh.clone() only performs a shallow copy of reference to contained geometry, so this can be used to perform a deeper copy of the mesh object as required.
