### PR TITLE
legacy shaders support fix

### DIFF
--- a/src/alternativa/engine3d/materials/compiler/Procedure.as
+++ b/src/alternativa/engine3d/materials/compiler/Procedure.as
@@ -185,6 +185,7 @@ package alternativa.engine3d.materials.compiler {
 		private const agalParser:RegExp = /[A-Za-z]+(((\[.+\])|(\d+))(\.[xyzw]{1,4})?(\ *\<.*>)?)?/g;
 
 		private function writeAGALExpression(source:String):void {
+			if (/^\s*$/.test(source)) return;
 			var commentIndex:int = source.indexOf("//");
 			if (commentIndex >= 0) {
 				source = source.substr(0, commentIndex);


### PR DESCRIPTION
I was just told this breaks http://davidejones.com/blog/1599-switching-colour-alternativa3d/ Apparently a3d compiler behaves differently from AGALMiniAssembler :)
