### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-##Our resouces
+## Our resouces
 
 [![facebook](http://alternativaplatform.github.com/Alternativa3D/images/facebook.png)](http://www.facebook.com/alternativaplatform)  
 [![twitter](http://alternativaplatform.github.com/Alternativa3D/images/twitter.png)](https://twitter.com/Alternativa3D)  
 [Blog](http://blog.alternativaplatform.com/en/)  
 [Forum](http://forum.alternativaplatform.com/forums/list.page)
 
-##Description
+## Description
 We position Alternativa3D as a high-tech engine that supports hardware acceleration for browser application development. Initially, the engine was designed to meet our own needs but we realized that it wouldn't be fair to limit the use of the technology to just one game. That is why we decided to make it an open source engine. Since our top priorities are high performance and resource efficiency, we recommend using it for games with high-resolution graphics.
 
 We will gladly partner with ambitious professionals to develop features that will be used in large projects.
 
-##Projects using Alternativa3D
+## Projects using Alternativa3D
 
  [![Play](http://alternativaplatform.github.com/Alternativa3D/images/combatsector \(cover\).jpg)](http://game.combatsector.com?instant=1)   
  MMO Top-Down Shooter game based on futuristic gladiator fights   
@@ -29,18 +29,18 @@ We will gladly partner with ambitious professionals to develop features that wil
  ![](http://alternativaplatform.github.com/Alternativa3D/images/deadzone 4.jpg)&nbsp;
  ![](http://alternativaplatform.github.com/Alternativa3D/images/deadzone 5.jpg)&nbsp;
 
-##Videos
+## Videos
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/maxracer\(video\).jpg)](http://www.youtube.com/watch?v=tgwi0lWgX8w)
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/metro\(video\).jpg)](http://www.youtube.com/watch?v=Aein6drd_Hk)
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/ostrova\(video\).jpg)](http://www.youtube.com/watch?v=hCXxCD_GYTA)
 
-##Demos
+## Demos
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/maxracer\(swf\).jpg)](http://alternativaplatform.com/ru/demos/crash/)
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/arena\(swf\).jpg)](http://alternativaplatform.com/ru/demos/arena/)
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/crush\(swf\).jpg)](http://alternativaplatform.com/ru/demos/crash/)
 [![Play](http://alternativaplatform.github.com/Alternativa3D/images/dir_shadow\(swf\).jpg)](http://wiki.alternativaplatform.com/DirectionalLightShadow_Demo)
 
-##Product features:
+## Product features:
  - Based on Flash Player technology
  - API is analagous to API Flash
  - 3ds Max compatible
@@ -57,9 +57,9 @@ We will gladly partner with ambitious professionals to develop features that wil
  - Support of the particle system
 
 
-#For Users
+# For Users
 
-##Repository
+## Repository
 We offer the community not only use of the engine but involvement in its further development. If you have found a bug you can notify us about it. You can use repositories, create your own branches, experiment and recommend whatever changes you think should be made. All useful changes will be employed in the engine architecture, and your contribution will be made known to the public though [facebook](http://www.facebook.com/alternativaplatform) and [twitter](https://twitter.com/AltrntivaPltfrm).
 
 
@@ -67,11 +67,11 @@ We offer the community not only use of the engine but involvement in its further
 [Alternativa3DUtils](https://github.com/AlternativaPlatform/Alternativa3DUtils) - Add-ins and enhancers. You don't need to know the shader programming to create utilities, so feel free to experiement.  
 [Alternativa3DExamples](https://github.com/AlternativaPlatform/Alternativa3DExamples) - Examples of using the engine with various features demonstrated. If we like your examples they will appear in the main repository branch.  
 
-##Documentation
+## Documentation
 [Online API reference](http://alternativaplatform.com/en/docs/8.32.0/)  
 [Download as an archive](http://alternativaplatform.com/en/docs/8.32.0/alternativa3d8_help_en.zip)
 
-##Articles on the use of the product
+## Articles on the use of the product
 [Simple aplication](http://wiki.alternativaplatform.com/Template_Tutorial#Alternativa3D_8)  
 [Compilation of Alternativa3D from source codes](http://wiki.alternativaplatform.com/Compilation_of_Alternativa3D_from_source_codes)  
 [Alternativa 8 for Dummies Part I](http://wiki.alternativaplatform.com/Alternativa_8_for_Dummies_Part_I) © [redefy](http://redefy.net/)  
@@ -87,19 +87,19 @@ We offer the community not only use of the engine but involvement in its further
 [Dragging a 3d object](http://davidejones.com/blog/1566-dragging-3d-object-alternativa3d-8/) © [Davide Jones](http://davidejones.com/)  
 [Rendering to bitmap](http://davidejones.com/blog/1577-rendering-bitmap-alternativa3d-8/) © [Davide Jones](http://davidejones.com/)
 
-##Plugin for Blender
+## Plugin for Blender
 [Blender Alternativa Addon](https://github.com/davidejones/alternativa3d_tools) © [Davide Jones](http://davidejones.com/)  
 [Blender Alternativa Addon - Installing](http://wiki.alternativaplatform.com/Blender_Alternativa_Addon_-_Installing) © [Davide Jones](http://davidejones.com/)  
 [Blender Alternativa Addon - Optimizing a3d export](http://wiki.alternativaplatform.com/Blender_Alternativa_Addon_-_Optimizing_a3d_export) © [Davide Jones](http://davidejones.com/)  
 [Blender Alternativa Addon - Using LOD](http://wiki.alternativaplatform.com/Blender_Alternativa_Addon_-_Using_LOD) © [Davide Jones](http://davidejones.com/)  
 [Blender Alternativa Addon - Using Sprites](http://wiki.alternativaplatform.com/Blender_Alternativa_Addon_-_Using_Sprites) © [Davide Jones](http://davidejones.com/)
 
-##Plugin for Autodesk 3ds Max
+## Plugin for Autodesk 3ds Max
 [Plugin for 3ds Max 2012](http://alternativaplatform.com/public/plugins_3dsmax2012.zip)  
 [Plugin for 3ds Max 2011](http://alternativaplatform.com/public/plugins_3dsmax2011.zip)  
 [Plugin for 3ds Max 2010](http://alternativaplatform.com/public/plugins_3dsmax2010.zip)
 
-##Literature
+## Literature
 [Environment and Refraction](http://wiki.alternativaplatform.com/Environment_and_Refraction)  
 [Custom materials shaders and intersectionRay](http://wiki.alternativaplatform.com/Custom_materials_shaders_and_intersectionRay)  
 [Example of material for creating the effect of atmosphere](http://wiki.alternativaplatform.com/Example_of_material_for_creating_the_effect_of_atmosphere)  
@@ -108,7 +108,7 @@ We offer the community not only use of the engine but involvement in its further
 [Why can i not see the object](http://wiki.alternativaplatform.com/Why_can_i_not_see_the_object)  
 [Z-fighting](http://en.wikipedia.org/wiki/Z-fighting)
 
-##Our helpers
+## Our helpers
 [Davide Jones](http://davidejones.com/)  
 [redefy](http://redefy.net/)   
 (All those who took part in the development and writing of posts, please contact us)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
